### PR TITLE
Etcd test

### DIFF
--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -24,11 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/utils/requestutil"
+	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
 func TestLabelMatcher(t *testing.T) {
@@ -93,7 +93,7 @@ func TestLocalLogBackendUsingFile(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
 	backend := NewLocalLogBackend(true)
-	fname := initLog()
+	fname := testutil.InitLog("info")
 	defer os.Remove(fname)
 	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:2379/test?test=test", strings.NewReader("testBody"))
 	re.False(backend.ProcessHTTPRequest(req))
@@ -125,7 +125,7 @@ func BenchmarkLocalLogAuditUsingTerminal(b *testing.B) {
 func BenchmarkLocalLogAuditUsingFile(b *testing.B) {
 	b.StopTimer()
 	backend := NewLocalLogBackend(true)
-	fname := initLog()
+	fname := testutil.InitLog("info")
 	defer os.Remove(fname)
 	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:2379/test?test=test", strings.NewReader("testBody"))
 	b.StartTimer()
@@ -134,16 +134,4 @@ func BenchmarkLocalLogAuditUsingFile(b *testing.B) {
 		req = req.WithContext(requestutil.WithRequestInfo(req.Context(), info))
 		backend.ProcessHTTPRequest(req)
 	}
-}
-
-func initLog() string {
-	cfg := &log.Config{}
-	f, _ := os.CreateTemp("/tmp", "pd_tests")
-	fname := f.Name()
-	f.Close()
-	cfg.File.Filename = fname
-	cfg.Level = "info"
-	lg, p, _ := log.InitLogger(cfg)
-	log.ReplaceGlobals(lg, p)
-	return fname
 }

--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -93,7 +93,7 @@ func TestLocalLogBackendUsingFile(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
 	backend := NewLocalLogBackend(true)
-	fname := testutil.InitLog("info")
+	fname := testutil.InitTempFileLogger("info")
 	defer os.Remove(fname)
 	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:2379/test?test=test", strings.NewReader("testBody"))
 	re.False(backend.ProcessHTTPRequest(req))
@@ -125,7 +125,7 @@ func BenchmarkLocalLogAuditUsingTerminal(b *testing.B) {
 func BenchmarkLocalLogAuditUsingFile(b *testing.B) {
 	b.StopTimer()
 	backend := NewLocalLogBackend(true)
-	fname := testutil.InitLog("info")
+	fname := testutil.InitTempFileLogger("info")
 	defer os.Remove(fname)
 	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:2379/test?test=test", strings.NewReader("testBody"))
 	b.StartTimer()

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -22,25 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"go.etcd.io/etcd/clientv3"
-	"go.etcd.io/etcd/embed"
 )
 
 func TestLease(t *testing.T) {
 	re := require.New(t)
-	cfg := etcdutil.NewTestSingleConfig(t)
-	etcd, err := embed.StartEtcd(cfg)
-	defer func() {
-		etcd.Close()
-	}()
-	re.NoError(err)
-
-	ep := cfg.LCUrls[0].String()
-	client, err := clientv3.New(clientv3.Config{
-		Endpoints: []string{ep},
-	})
-	re.NoError(err)
-
-	<-etcd.Server.ReadyNotify()
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
+	defer clean()
 
 	// Create the lease.
 	lease1 := &lease{
@@ -104,20 +91,8 @@ func TestLease(t *testing.T) {
 
 func TestLeaseKeepAlive(t *testing.T) {
 	re := require.New(t)
-	cfg := etcdutil.NewTestSingleConfig(t)
-	etcd, err := embed.StartEtcd(cfg)
-	defer func() {
-		etcd.Close()
-	}()
-	re.NoError(err)
-
-	ep := cfg.LCUrls[0].String()
-	client, err := clientv3.New(clientv3.Config{
-		Endpoints: []string{ep},
-	})
-	re.NoError(err)
-
-	<-etcd.Server.ReadyNotify()
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
+	defer clean()
 
 	// Create the lease.
 	lease := &lease{

--- a/pkg/encryption/key_manager_test.go
+++ b/pkg/encryption/key_manager_test.go
@@ -45,13 +45,11 @@ func getTestDataKey() []byte {
 	return key
 }
 
-func newTestEtcd(t *testing.T, re *require.Assertions) (client *clientv3.Client) {
+func newTestEtcd(t *testing.T) (client *clientv3.Client) {
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
-
 	t.Cleanup(func() {
 		clean()
 	})
-
 	return client
 }
 
@@ -87,7 +85,7 @@ func checkMasterKeyMeta(re *require.Assertions, value []byte, meta *encryptionpb
 func TestNewKeyManagerBasic(t *testing.T) {
 	re := require.New(t)
 	// Initialize.
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	// Use default config.
 	config := &Config{}
 	err := config.Adjust()
@@ -109,7 +107,7 @@ func TestNewKeyManagerBasic(t *testing.T) {
 func TestNewKeyManagerWithCustomConfig(t *testing.T) {
 	re := require.New(t)
 	// Initialize.
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	// Custom config
 	rotatePeriod, err := time.ParseDuration("100h")
@@ -147,7 +145,7 @@ func TestNewKeyManagerWithCustomConfig(t *testing.T) {
 func TestNewKeyManagerLoadKeys(t *testing.T) {
 	re := require.New(t)
 	// Initialize.
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Use default config.
@@ -188,7 +186,7 @@ func TestNewKeyManagerLoadKeys(t *testing.T) {
 func TestGetCurrentKey(t *testing.T) {
 	re := require.New(t)
 	// Initialize.
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	// Use default config.
 	config := &Config{}
 	err := config.Adjust()
@@ -231,7 +229,7 @@ func TestGetCurrentKey(t *testing.T) {
 func TestGetKey(t *testing.T) {
 	re := require.New(t)
 	// Initialize.
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Store initial keys in etcd.
@@ -286,7 +284,7 @@ func TestGetKey(t *testing.T) {
 func TestLoadKeyEmpty(t *testing.T) {
 	re := require.New(t)
 	// Initialize.
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Store initial keys in etcd.
@@ -322,7 +320,7 @@ func TestWatcher(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper
@@ -398,7 +396,7 @@ func TestWatcher(t *testing.T) {
 func TestSetLeadershipWithEncryptionOff(t *testing.T) {
 	re := require.New(t)
 	// Initialize.
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	// Use default config.
 	config := &Config{}
 	err := config.Adjust()
@@ -423,7 +421,7 @@ func TestSetLeadershipWithEncryptionEnabling(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper
@@ -476,7 +474,7 @@ func TestSetLeadershipWithEncryptionMethodChanged(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper
@@ -552,7 +550,7 @@ func TestSetLeadershipWithCurrentKeyExposed(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper
@@ -623,7 +621,7 @@ func TestSetLeadershipWithCurrentKeyExpired(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper
@@ -698,7 +696,7 @@ func TestSetLeadershipWithMasterKeyChanged(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	keyFile2 := newTestKeyFile(t, re, testMasterKey2)
 	leadership := newTestLeader(re, client)
@@ -763,7 +761,7 @@ func TestSetLeadershipWithMasterKeyChanged(t *testing.T) {
 func TestSetLeadershipMasterKeyWithCiphertextKey(t *testing.T) {
 	re := require.New(t)
 	// Initialize.
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper
@@ -841,7 +839,7 @@ func TestSetLeadershipWithEncryptionDisabling(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper
@@ -897,7 +895,7 @@ func TestKeyRotation(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper
@@ -993,7 +991,7 @@ func TestKeyRotationConflict(t *testing.T) {
 	// Initialize.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client := newTestEtcd(t, re)
+	client := newTestEtcd(t)
 	keyFile := newTestKeyFile(t, re)
 	leadership := newTestLeader(re, client)
 	// Setup helper

--- a/pkg/mcs/discovery/discover_test.go
+++ b/pkg/mcs/discovery/discover_test.go
@@ -21,28 +21,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
-	"go.etcd.io/etcd/clientv3"
-	"go.etcd.io/etcd/embed"
 )
 
 func TestDiscover(t *testing.T) {
 	re := require.New(t)
-	cfg := etcdutil.NewTestSingleConfig(t)
-	etcd, err := embed.StartEtcd(cfg)
-	defer func() {
-		etcd.Close()
-	}()
-	re.NoError(err)
-
-	ep := cfg.LCUrls[0].String()
-	re.NoError(err)
-
-	client, err := clientv3.NewFromURL(ep)
-	re.NoError(err)
-
-	<-etcd.Server.ReadyNotify()
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
+	defer clean()
 	sr1 := NewServiceRegister(context.Background(), client, "12345", "test_service", "127.0.0.1:1", "127.0.0.1:1", 1)
-	err = sr1.Register()
+	err := sr1.Register()
 	re.NoError(err)
 	sr2 := NewServiceRegister(context.Background(), client, "12345", "test_service", "127.0.0.1:2", "127.0.0.1:2", 1)
 	err = sr2.Register()
@@ -64,20 +50,8 @@ func TestDiscover(t *testing.T) {
 
 func TestServiceRegistryEntry(t *testing.T) {
 	re := require.New(t)
-	cfg := etcdutil.NewTestSingleConfig(t)
-	etcd, err := embed.StartEtcd(cfg)
-	defer func() {
-		etcd.Close()
-	}()
-	re.NoError(err)
-
-	ep := cfg.LCUrls[0].String()
-	re.NoError(err)
-
-	client, err := clientv3.NewFromURL(ep)
-	re.NoError(err)
-
-	<-etcd.Server.ReadyNotify()
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
+	defer clean()
 	entry1 := &ServiceRegistryEntry{ServiceAddr: "127.0.0.1:1"}
 	s1, err := entry1.Serialize()
 	re.NoError(err)

--- a/pkg/storage/kv/kv_test.go
+++ b/pkg/storage/kv/kv_test.go
@@ -24,21 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"go.etcd.io/etcd/clientv3"
-	"go.etcd.io/etcd/embed"
 )
 
 func TestEtcd(t *testing.T) {
 	re := require.New(t)
-	cfg := etcdutil.NewTestSingleConfig(t)
-	etcd, err := embed.StartEtcd(cfg)
-	re.NoError(err)
-	defer etcd.Close()
-
-	ep := cfg.LCUrls[0].String()
-	client, err := clientv3.New(clientv3.Config{
-		Endpoints: []string{ep},
-	})
-	re.NoError(err)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
+	defer clean()
 	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
 
 	kv := NewEtcdKVBase(client, rootPath)

--- a/pkg/storage/storage_tso_test.go
+++ b/pkg/storage/storage_tso_test.go
@@ -27,7 +27,8 @@ import (
 
 func TestSaveLoadTimestamp(t *testing.T) {
 	re := require.New(t)
-	storage := newTestStorage(t)
+	storage, clean := newTestStorage(t)
+	defer clean()
 	expectedTS := time.Now().Round(0)
 	err := storage.SaveTimestamp(endpoint.TimestampKey, expectedTS)
 	re.NoError(err)
@@ -38,7 +39,8 @@ func TestSaveLoadTimestamp(t *testing.T) {
 
 func TestGlobalLocalTimestamp(t *testing.T) {
 	re := require.New(t)
-	storage := newTestStorage(t)
+	storage, clean := newTestStorage(t)
+	defer clean()
 	ltaKey := "lta"
 	dc1LocationKey, dc2LocationKey := "dc1", "dc2"
 	localTS1 := time.Now().Round(0)
@@ -65,7 +67,8 @@ func TestGlobalLocalTimestamp(t *testing.T) {
 
 func TestTimestampTxn(t *testing.T) {
 	re := require.New(t)
-	storage := newTestStorage(t)
+	storage, clean := newTestStorage(t)
+	defer clean()
 	globalTS1 := time.Now().Round(0)
 	err := storage.SaveTimestamp(endpoint.TimestampKey, globalTS1)
 	re.NoError(err)
@@ -79,9 +82,8 @@ func TestTimestampTxn(t *testing.T) {
 	re.Equal(globalTS1, ts)
 }
 
-func newTestStorage(t *testing.T) Storage {
+func newTestStorage(t *testing.T) (Storage, func()) {
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
-	defer clean()
 	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
-	return NewStorageWithEtcdBackend(client, rootPath)
+	return NewStorageWithEtcdBackend(client, rootPath), clean
 }

--- a/pkg/storage/storage_tso_test.go
+++ b/pkg/storage/storage_tso_test.go
@@ -27,12 +27,7 @@ import (
 
 func TestSaveLoadTimestamp(t *testing.T) {
 	re := require.New(t)
-
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
-	defer clean()
-	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
-	storage := NewStorageWithEtcdBackend(client, rootPath)
-
+	storage := newTestStorage(t)
 	expectedTS := time.Now().Round(0)
 	err := storage.SaveTimestamp(endpoint.TimestampKey, expectedTS)
 	re.NoError(err)
@@ -43,12 +38,7 @@ func TestSaveLoadTimestamp(t *testing.T) {
 
 func TestGlobalLocalTimestamp(t *testing.T) {
 	re := require.New(t)
-
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
-	defer clean()
-	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
-	storage := NewStorageWithEtcdBackend(client, rootPath)
-
+	storage := newTestStorage(t)
 	ltaKey := "lta"
 	dc1LocationKey, dc2LocationKey := "dc1", "dc2"
 	localTS1 := time.Now().Round(0)
@@ -75,12 +65,7 @@ func TestGlobalLocalTimestamp(t *testing.T) {
 
 func TestTimestampTxn(t *testing.T) {
 	re := require.New(t)
-
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
-	defer clean()
-	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
-	storage := NewStorageWithEtcdBackend(client, rootPath)
-
+	storage := newTestStorage(t)
 	globalTS1 := time.Now().Round(0)
 	err := storage.SaveTimestamp(endpoint.TimestampKey, globalTS1)
 	re.NoError(err)
@@ -92,4 +77,11 @@ func TestTimestampTxn(t *testing.T) {
 	ts, err := storage.LoadTimestamp("")
 	re.NoError(err)
 	re.Equal(globalTS1, ts)
+}
+
+func newTestStorage(t *testing.T) Storage {
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
+	defer clean()
+	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
+	return NewStorageWithEtcdBackend(client, rootPath)
 }

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	mcsutils "github.com/tikv/pd/pkg/mcs/utils"
 	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/tsoutil"
@@ -67,7 +68,8 @@ func (suite *keyspaceGroupManagerTestSuite) SetupSuite() {
 	t := suite.T()
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 	suite.ClusterID = rand.Uint64()
-	suite.backendEndpoints, suite.etcdClient, suite.clean = startEmbeddedEtcd(t)
+	servers, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
+	suite.backendEndpoints, suite.etcdClient, suite.clean = servers[0].Config().LCUrls[0].String(), client, clean
 	suite.cfg = suite.createConfig()
 }
 

--- a/pkg/tso/testutil.go
+++ b/pkg/tso/testutil.go
@@ -15,14 +15,9 @@
 package tso
 
 import (
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
-	"go.etcd.io/etcd/clientv3"
-	"go.etcd.io/etcd/embed"
 )
 
 var _ ServiceConfig = (*TestServiceConfig)(nil)
@@ -89,24 +84,4 @@ func (c *TestServiceConfig) GetMaxResetTSGap() time.Duration {
 // GetTLSConfig returns the TLSConfig field of TestServiceConfig.
 func (c *TestServiceConfig) GetTLSConfig() *grpcutil.TLSConfig {
 	return c.TLSConfig
-}
-
-func startEmbeddedEtcd(t *testing.T) (backendEndpoint string, etcdClient *clientv3.Client, clean func()) {
-	re := require.New(t)
-	cfg := etcdutil.NewTestSingleConfig(t)
-	etcd, err := embed.StartEtcd(cfg)
-	re.NoError(err)
-	clean = func() {
-		etcd.Close()
-	}
-
-	backendEndpoint = cfg.LCUrls[0].String()
-	re.NoError(err)
-
-	etcdClient, err = clientv3.NewFromURL(backendEndpoint)
-	re.NoError(err)
-
-	<-etcd.Server.ReadyNotify()
-
-	return
 }

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -621,7 +621,7 @@ func (suite *loopWatcherTestSuite) TestWatcherBreak() {
 
 func (suite *loopWatcherTestSuite) TestWatcherRequestProgress() {
 	checkWatcherRequestProgress := func(injectWatchChanBlock bool) {
-		fname := testutil.InitLog("debug")
+		fname := testutil.InitTempFileLogger("debug")
 		defer os.Remove(fname)
 
 		watcher := NewLoopWatcher(

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -194,21 +194,15 @@ func TestEtcdScaleInAndOut(t *testing.T) {
 
 	// Create two etcd clients with etcd1 as endpoint.
 	client1, err := CreateEtcdClient(nil, cfg1.LCUrls) // execute member change operation with this client
-	defer func() {
-		client1.Close()
-	}()
 	re.NoError(err)
+	defer client1.Close()
 	client2, err := CreateEtcdClient(nil, cfg1.LCUrls) // check member change with this client
-	defer func() {
-		client2.Close()
-	}()
 	re.NoError(err)
+	defer client2.Close()
 
 	// Add a new member and check members
 	etcd2 := MustAddEtcdMember(t, &cfg1, client1)
-	defer func() {
-		etcd2.Close()
-	}()
+	defer etcd2.Close()
 	checkMembers(re, client2, []*embed.Etcd{etcd1, etcd2})
 
 	// scale in etcd1
@@ -283,10 +277,8 @@ func checkEtcdWithHangLeader(t *testing.T) error {
 	urls, err := types.NewURLs([]string{proxyAddr})
 	re.NoError(err)
 	client1, err := CreateEtcdClient(nil, urls)
-	defer func() {
-		client1.Close()
-	}()
 	re.NoError(err)
+	defer client1.Close()
 
 	// Add a new member
 	etcd2 := MustAddEtcdMember(t, &cfg1, client1)

--- a/pkg/utils/etcdutil/testutil.go
+++ b/pkg/utils/etcdutil/testutil.go
@@ -117,6 +117,8 @@ func addEtcdMemberWithRetry(t *testing.T, cfg1 *embed.Config, client *clientv3.C
 	if err != nil {
 		re.Contains(err.Error(), "error validating peerURLs")
 		if retry > 0 {
+			_, err := RemoveEtcdMember(client, addResp.Member.ID)
+			re.NoError(err)
 			return addEtcdMemberWithRetry(t, cfg1, client, retry-1)
 		}
 	}

--- a/pkg/utils/testutil/testutil.go
+++ b/pkg/utils/testutil/testutil.go
@@ -88,10 +88,11 @@ func CleanServer(dataDir string) {
 	os.RemoveAll(dataDir)
 }
 
-func InitLog(level string) string {
+// InitTempFileLogger initializes the logger and redirects the log output to a temporary file.
+func InitTempFileLogger(level string) (fname string) {
 	cfg := &log.Config{}
 	f, _ := os.CreateTemp("/tmp", "pd_tests")
-	fname := f.Name()
+	fname = f.Name()
 	f.Close()
 	cfg.File.Filename = fname
 	cfg.Level = level

--- a/pkg/utils/testutil/testutil.go
+++ b/pkg/utils/testutil/testutil.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -85,4 +86,16 @@ func MustNewGrpcClient(re *require.Assertions, addr string) pdpb.PDClient {
 func CleanServer(dataDir string) {
 	// Clean data directory
 	os.RemoveAll(dataDir)
+}
+
+func InitLog(level string) string {
+	cfg := &log.Config{}
+	f, _ := os.CreateTemp("/tmp", "pd_tests")
+	fname := f.Name()
+	f.Close()
+	cfg.File.Filename = fname
+	cfg.Level = level
+	lg, p, _ := log.InitLogger(cfg)
+	log.ReplaceGlobals(lg, p)
+	return fname
 }

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/pd/pkg/core"
@@ -453,13 +452,8 @@ func (suite *middlewareTestSuite) TestAuditPrometheusBackend() {
 }
 
 func (suite *middlewareTestSuite) TestAuditLocalLogBackend() {
-	tempStdoutFile, _ := os.CreateTemp("/tmp", "pd_tests")
-	defer os.Remove(tempStdoutFile.Name())
-	cfg := &log.Config{}
-	cfg.File.Filename = tempStdoutFile.Name()
-	cfg.Level = "info"
-	lg, p, _ := log.InitLogger(cfg)
-	log.ReplaceGlobals(lg, p)
+	fname := testutil.InitLog("info")
+	defer os.Remove(fname)
 	leader := suite.cluster.GetServer(suite.cluster.GetLeader())
 	input := map[string]interface{}{
 		"enable-audit": "true",
@@ -477,7 +471,7 @@ func (suite *middlewareTestSuite) TestAuditLocalLogBackend() {
 	suite.NoError(err)
 	_, err = io.ReadAll(resp.Body)
 	resp.Body.Close()
-	b, _ := os.ReadFile(tempStdoutFile.Name())
+	b, _ := os.ReadFile(fname)
 	suite.Contains(string(b), "audit log")
 	suite.NoError(err)
 	suite.Equal(http.StatusOK, resp.StatusCode)
@@ -667,13 +661,8 @@ func (suite *redirectorTestSuite) TestNotLeader() {
 func (suite *redirectorTestSuite) TestXForwardedFor() {
 	leader := suite.cluster.GetServer(suite.cluster.GetLeader())
 	suite.NoError(leader.BootstrapCluster())
-	tempStdoutFile, _ := os.CreateTemp("/tmp", "pd_tests")
-	defer os.Remove(tempStdoutFile.Name())
-	cfg := &log.Config{}
-	cfg.File.Filename = tempStdoutFile.Name()
-	cfg.Level = "info"
-	lg, p, _ := log.InitLogger(cfg)
-	log.ReplaceGlobals(lg, p)
+	fname := testutil.InitLog("info")
+	defer os.Remove(fname)
 
 	follower := suite.cluster.GetServer(suite.cluster.GetFollower())
 	addr := follower.GetAddr() + "/pd/api/v1/regions"
@@ -684,7 +673,7 @@ func (suite *redirectorTestSuite) TestXForwardedFor() {
 	defer resp.Body.Close()
 	suite.Equal(http.StatusOK, resp.StatusCode)
 	time.Sleep(1 * time.Second)
-	b, _ := os.ReadFile(tempStdoutFile.Name())
+	b, _ := os.ReadFile(fname)
 	l := string(b)
 	suite.Contains(l, "/pd/api/v1/regions")
 	suite.NotContains(l, suite.cluster.GetConfig().GetClientURLs())

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -452,7 +452,7 @@ func (suite *middlewareTestSuite) TestAuditPrometheusBackend() {
 }
 
 func (suite *middlewareTestSuite) TestAuditLocalLogBackend() {
-	fname := testutil.InitLog("info")
+	fname := testutil.InitTempFileLogger("info")
 	defer os.Remove(fname)
 	leader := suite.cluster.GetServer(suite.cluster.GetLeader())
 	input := map[string]interface{}{
@@ -661,7 +661,7 @@ func (suite *redirectorTestSuite) TestNotLeader() {
 func (suite *redirectorTestSuite) TestXForwardedFor() {
 	leader := suite.cluster.GetServer(suite.cluster.GetLeader())
 	suite.NoError(leader.BootstrapCluster())
-	fname := testutil.InitLog("info")
+	fname := testutil.InitTempFileLogger("info")
 	defer os.Remove(fname)
 
 	follower := suite.cluster.GetServer(suite.cluster.GetFollower())


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
