### PR TITLE
scheduler: preinitialize hot direction metrics

### DIFF
--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pingcap/log"
 
+	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	sche "github.com/tikv/pd/pkg/schedule/core"
 	"github.com/tikv/pd/pkg/schedule/operator"
@@ -57,6 +58,29 @@ var (
 	topnPosition = defaultTopnPosition
 	// statisticsInterval is the interval to update statistics information.
 	statisticsInterval = time.Second
+
+	hotDirectionCounterTypes = []string{
+		movePeer.String(),
+		moveLeader.String(),
+		transferLeader.String(),
+	}
+	hotDirectionCounterDirections = []string{
+		"in",
+		"out",
+		"in-for-revert",
+		"out-for-revert",
+	}
+	hotDirectionCounterDims = func() []string {
+		dims := make([]string, 0, utils.DimLen*2+1)
+		for dim := 0; dim < utils.DimLen; dim++ {
+			name := utils.DimToString(dim)
+			if name == "" {
+				continue
+			}
+			dims = append(dims, name, name+"-only")
+		}
+		return append(dims, "all")
+	}()
 )
 
 type baseHotScheduler struct {
@@ -73,9 +97,10 @@ type baseHotScheduler struct {
 	// be selected if its owner region is tracked in this attribute.
 	regionPendings map[uint64]*pendingInfluence
 	// types is the resource types that the scheduler considers.
-	types           []resourceType
-	updateReadTime  time.Time
-	updateWriteTime time.Time
+	types                         []resourceType
+	updateReadTime                time.Time
+	updateWriteTime               time.Time
+	initializedHotDirectionStores map[uint64]struct{}
 }
 
 func newBaseHotScheduler(
@@ -85,9 +110,10 @@ func newBaseHotScheduler(
 ) *baseHotScheduler {
 	base := NewBaseScheduler(opController, types.BalanceHotRegionScheduler, schedulerConfig)
 	ret := &baseHotScheduler{
-		BaseScheduler:  base,
-		regionPendings: make(map[uint64]*pendingInfluence),
-		stHistoryLoads: statistics.NewStoreHistoryLoads(sampleDuration, sampleInterval),
+		BaseScheduler:                 base,
+		regionPendings:                make(map[uint64]*pendingInfluence),
+		stHistoryLoads:                statistics.NewStoreHistoryLoads(sampleDuration, sampleInterval),
+		initializedHotDirectionStores: make(map[uint64]struct{}),
 	}
 	for ty := resourceType(0); ty < resourceTypeLen; ty++ {
 		ret.types = append(ret.types, ty)
@@ -99,7 +125,9 @@ func newBaseHotScheduler(
 // prepareForBalance calculate the summary of pending Influence for each store and prepare the load detail for
 // each store, only update read or write load detail
 func (s *baseHotScheduler) prepareForBalance(typ resourceType, cluster sche.SchedulerCluster) {
-	storeInfos := statistics.SummaryStoreInfos(cluster.GetStores())
+	stores := cluster.GetStores()
+	s.preInitializeHotDirectionCounters(stores)
+	storeInfos := statistics.SummaryStoreInfos(stores)
 	s.summaryPendingInfluence(storeInfos)
 	storesLoads := cluster.GetStoresLoads()
 	isTraceRegionFlow := cluster.GetSchedulerConfig().IsTraceRegionFlow()
@@ -135,6 +163,26 @@ func (s *baseHotScheduler) prepareForBalance(typ resourceType, cluster sche.Sche
 		}
 	default:
 		log.Error("invalid resource type", zap.String("type", typ.String()))
+	}
+}
+
+func (s *baseHotScheduler) preInitializeHotDirectionCounters(stores []*core.StoreInfo) {
+	for _, store := range stores {
+		storeID := store.GetID()
+		if _, ok := s.initializedHotDirectionStores[storeID]; ok {
+			continue
+		}
+		storeLabel := strconv.FormatUint(storeID, 10)
+		for _, typ := range hotDirectionCounterTypes {
+			for _, rw := range []utils.RWType{utils.Read, utils.Write} {
+				for _, direction := range hotDirectionCounterDirections {
+					for _, dim := range hotDirectionCounterDims {
+						hotDirectionCounter.WithLabelValues(typ, rw.String(), storeLabel, direction, dim)
+					}
+				}
+			}
+		}
+		s.initializedHotDirectionStores[storeID] = struct{}{}
 	}
 }
 

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -16,7 +16,6 @@ package schedulers
 
 import (
 	"fmt"
-	"math"
 	"math/rand/v2"
 	"net/http"
 	"strconv"
@@ -231,10 +230,6 @@ func (s *baseHotScheduler) summaryPendingInfluence(storeInfos map[uint64]*statis
 			})
 		}
 	}
-}
-
-func normalizeHotLoadSignature(load float64) float64 {
-	return math.Round(load*1000) / 1000
 }
 
 func (s *baseHotScheduler) randomType() resourceType {

--- a/pkg/schedule/schedulers/hot_region_solver.go
+++ b/pkg/schedule/schedulers/hot_region_solver.go
@@ -505,7 +505,7 @@ func (bs *balanceSolver) hotScheduleScopeKey() hotScheduleScopeKey {
 	}
 }
 
-func (bs *balanceSolver) sourceLoadForQualification(detail *statistics.StoreLoadDetail) *statistics.StoreLoad {
+func (*balanceSolver) sourceLoadForQualification(detail *statistics.StoreLoadDetail) *statistics.StoreLoad {
 	if detail == nil || detail.LoadPred == nil {
 		return nil
 	}

--- a/pkg/schedule/schedulers/hot_region_solver.go
+++ b/pkg/schedule/schedulers/hot_region_solver.go
@@ -1020,34 +1020,45 @@ func (bs *balanceSolver) isTolerance(dim int, reverse bool) bool {
 	if srcRate <= dstRate {
 		return false
 	}
-	ampFactor := pendingAmpFactor
-	// For read+cpu,byte, scale the amplification factor by the number of in-flight ops
-	// from the same source store. This progressively throttles burst scheduling:
-	// 0 pending ops → factor=2 (unchanged), 1 → 4, 2 → 6, 3 → 8, etc.
-	if bs.isReadCPUByte() {
-		srcStoreID := bs.cur.srcStore.GetID()
-		if reverse {
-			srcStoreID = bs.cur.dstStore.GetID()
-		}
-		srcPendingCount := bs.countPendingOpsFromStore(srcStoreID)
-		ampFactor = pendingAmpFactor * float64(1+srcPendingCount)
+	if bs.shouldRejectReadCPUByteByErrorReduction() {
+		return false
 	}
+	ampFactor := pendingAmpFactor
 	pendingAmp := 1 + ampFactor*srcRate/(srcRate-dstRate)
 	return srcRate-pendingAmp*srcPending > dstRate+pendingAmp*dstPending
 }
 
-// countPendingOpsFromStore counts how many pending ops originate from the given store.
-func (bs *balanceSolver) countPendingOpsFromStore(storeID uint64) int {
-	count := 0
-	for _, p := range bs.sche.regionPendings {
-		for _, from := range p.froms {
-			if from == storeID {
-				count++
-				break
-			}
-		}
+// shouldRejectReadCPUByteByErrorReduction only allows ops that strictly reduce the first-priority CPU error.
+// The second-priority byte dimension still participates in the existing rank/score comparison,
+// but it must not rescue an op whose CPU error does not improve.
+func (bs *balanceSolver) shouldRejectReadCPUByteByErrorReduction() bool {
+	if !bs.isReadCPUByte() || bs.cur == nil || bs.cur.srcStore == nil || bs.cur.dstStore == nil {
+		return false
 	}
-	return count
+	if len(bs.cur.cachedPeersRate) != utils.DimLen {
+		if bs.cur.mainPeerStat == nil {
+			return false
+		}
+		bs.cur.calcPeersRate(bs.firstPriority, bs.secondPriority)
+	}
+	return bs.compareTotalErrorAfterPeer(bs.firstPriority) >= 0
+}
+
+func (bs *balanceSolver) compareTotalErrorAfterPeer(dim int) int {
+	srcRate, dstRate := bs.cur.getExtremeLoad(dim)
+	peerRate := bs.cur.getPeersRateFromCache(dim)
+	srcExpect := bs.cur.srcStore.LoadPred.Expect.Loads[dim]
+	dstExpect := bs.cur.dstStore.LoadPred.Expect.Loads[dim]
+	before := math.Abs(srcRate-srcExpect) + math.Abs(dstRate-dstExpect)
+	after := math.Abs(srcRate-peerRate-srcExpect) + math.Abs(dstRate+peerRate-dstExpect)
+	switch {
+	case after < before-1e-6:
+		return -1
+	case after > before+1e-6:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func (bs *balanceSolver) getMinRate(dim int) float64 {

--- a/pkg/schedule/schedulers/hot_region_solver_test.go
+++ b/pkg/schedule/schedulers/hot_region_solver_test.go
@@ -378,18 +378,24 @@ func TestMaxZombieDuration(t *testing.T) {
 	}
 }
 
-func TestIsToleranceReadCPUByteAdaptivePendingAmp(t *testing.T) {
+func TestReadCPUByteErrorReductionGateAllowsUsefulCPUImprovement(t *testing.T) {
 	re := require.New(t)
-	srcStore := core.NewStoreInfoWithLabel(1, map[string]string{})
-	dstStore := core.NewStoreInfoWithLabel(2, map[string]string{})
+	srcStore := core.NewStoreInfoWithLabel(1, nil)
+	dstStore := core.NewStoreInfoWithLabel(2, nil)
 	src := &statistics.StoreLoadDetail{
 		StoreSummaryInfo: &statistics.StoreSummaryInfo{StoreInfo: srcStore},
 		LoadPred: &statistics.StoreLoadPred{
 			Current: statistics.StoreLoad{Loads: statistics.Loads{
-				utils.CPUDim: 594,
+				utils.CPUDim:  594,
+				utils.ByteDim: 33160565.2,
 			}},
 			Future: statistics.StoreLoad{Loads: statistics.Loads{
-				utils.CPUDim: 513,
+				utils.CPUDim:  515,
+				utils.ByteDim: 33160565.2,
+			}},
+			Expect: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  184.83333333333334,
+				utils.ByteDim: 101597443.86666667,
 			}},
 		},
 	}
@@ -397,28 +403,140 @@ func TestIsToleranceReadCPUByteAdaptivePendingAmp(t *testing.T) {
 		StoreSummaryInfo: &statistics.StoreSummaryInfo{StoreInfo: dstStore},
 		LoadPred: &statistics.StoreLoadPred{
 			Current: statistics.StoreLoad{Loads: statistics.Loads{
-				utils.CPUDim: 47,
+				utils.CPUDim:  108,
+				utils.ByteDim: 110154379.8,
 			}},
 			Future: statistics.StoreLoad{Loads: statistics.Loads{
-				utils.CPUDim: 47,
+				utils.CPUDim:  108,
+				utils.ByteDim: 110154379.8,
+			}},
+			Expect: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  184.83333333333334,
+				utils.ByteDim: 101597443.86666667,
 			}},
 		},
 	}
 	bs := &balanceSolver{
-		sche:           &hotScheduler{baseHotScheduler: &baseHotScheduler{regionPendings: make(map[uint64]*pendingInfluence)}},
 		rwTy:           utils.Read,
 		resourceTy:     readLeader,
 		firstPriority:  utils.CPUDim,
 		secondPriority: utils.ByteDim,
 		cur: &solution{
-			srcStore: src,
-			dstStore: dst,
+			srcStore:     src,
+			dstStore:     dst,
+			mainPeerStat: &statistics.HotPeerStat{Loads: []float64{0, 0, 0, 33}},
 		},
 	}
+	bs.cur.calcPeersRate(utils.CPUDim, utils.ByteDim)
 	re.True(bs.isTolerance(utils.CPUDim, false))
+	re.False(bs.shouldRejectReadCPUByteByErrorReduction())
+}
 
-	bs.sche.regionPendings[1] = &pendingInfluence{froms: []uint64{1}}
-	bs.sche.regionPendings[2] = &pendingInfluence{froms: []uint64{1}}
+func TestReadCPUByteErrorReductionGateRejectsReverseOvershoot(t *testing.T) {
+	re := require.New(t)
+	srcStore := core.NewStoreInfoWithLabel(15, nil)
+	dstStore := core.NewStoreInfoWithLabel(1, nil)
+	src := &statistics.StoreLoadDetail{
+		StoreSummaryInfo: &statistics.StoreSummaryInfo{StoreInfo: srcStore},
+		LoadPred: &statistics.StoreLoadPred{
+			Current: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  594,
+				utils.ByteDim: 242580736.2,
+			}},
+			Future: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  582,
+				utils.ByteDim: 228207645.2,
+			}},
+			Expect: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  322.5,
+				utils.ByteDim: 186479448.23333335,
+			}},
+		},
+	}
+	dst := &statistics.StoreLoadDetail{
+		StoreSummaryInfo: &statistics.StoreSummaryInfo{StoreInfo: dstStore},
+		LoadPred: &statistics.StoreLoadPred{
+			Current: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  380,
+				utils.ByteDim: 79170347,
+			}},
+			Future: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  380,
+				utils.ByteDim: 79170347,
+			}},
+			Expect: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  322.5,
+				utils.ByteDim: 186479448.23333335,
+			}},
+		},
+	}
+	bs := &balanceSolver{
+		rwTy:           utils.Read,
+		resourceTy:     readLeader,
+		firstPriority:  utils.CPUDim,
+		secondPriority: utils.ByteDim,
+		cur: &solution{
+			srcStore:     src,
+			dstStore:     dst,
+			mainPeerStat: &statistics.HotPeerStat{Loads: []float64{8853662, 0, 0, 8}},
+		},
+	}
+	bs.cur.calcPeersRate(utils.CPUDim, utils.ByteDim)
+	re.True(bs.shouldRejectReadCPUByteByErrorReduction())
+	re.False(bs.isTolerance(utils.CPUDim, false))
+}
+
+func TestReadCPUByteErrorReductionGateDoesNotLetByteRescueCPUTie(t *testing.T) {
+	re := require.New(t)
+	srcStore := core.NewStoreInfoWithLabel(1, nil)
+	dstStore := core.NewStoreInfoWithLabel(2, nil)
+	src := &statistics.StoreLoadDetail{
+		StoreSummaryInfo: &statistics.StoreSummaryInfo{StoreInfo: srcStore},
+		LoadPred: &statistics.StoreLoadPred{
+			Current: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  450,
+				utils.ByteDim: 100,
+			}},
+			Future: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  450,
+				utils.ByteDim: 100,
+			}},
+			Expect: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  440,
+				utils.ByteDim: 100,
+			}},
+		},
+	}
+	dst := &statistics.StoreLoadDetail{
+		StoreSummaryInfo: &statistics.StoreSummaryInfo{StoreInfo: dstStore},
+		LoadPred: &statistics.StoreLoadPred{
+			Current: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  445,
+				utils.ByteDim: 100,
+			}},
+			Future: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  445,
+				utils.ByteDim: 100,
+			}},
+			Expect: statistics.StoreLoad{Loads: statistics.Loads{
+				utils.CPUDim:  440,
+				utils.ByteDim: 100,
+			}},
+		},
+	}
+	bs := &balanceSolver{
+		rwTy:           utils.Read,
+		resourceTy:     readLeader,
+		firstPriority:  utils.CPUDim,
+		secondPriority: utils.ByteDim,
+		cur: &solution{
+			srcStore:     src,
+			dstStore:     dst,
+			mainPeerStat: &statistics.HotPeerStat{Loads: []float64{20, 0, 0, 5}},
+		},
+	}
+	bs.cur.calcPeersRate(utils.CPUDim, utils.ByteDim)
+	re.True(bs.shouldRejectReadCPUByteByErrorReduction())
 	re.False(bs.isTolerance(utils.CPUDim, false))
 }
 

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -80,6 +81,69 @@ func clearPendingInfluence(h *hotScheduler) {
 func newTestRegion(id uint64) *core.RegionInfo {
 	peers := []*metapb.Peer{{Id: id*100 + 1, StoreId: 1}, {Id: id*100 + 2, StoreId: 2}, {Id: id*100 + 3, StoreId: 3}}
 	return core.NewRegionInfo(&metapb.Region{Id: id, Peers: peers}, peers[0])
+}
+
+func getHotDirectionCounterValue(t *testing.T, labels map[string]string) (float64, bool) {
+	t.Helper()
+	re := require.New(t)
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	re.NoError(err)
+	for _, family := range metricFamilies {
+		if family.GetName() != "pd_scheduler_hot_region_direction" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			matched := true
+			for name, value := range labels {
+				found := false
+				for _, label := range metric.GetLabel() {
+					if label.GetName() == name && label.GetValue() == value {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return metric.GetCounter().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestPreInitializeHotDirectionCounters(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	const storeID = uint64(12345)
+	tc.AddLeaderStore(storeID, 1)
+
+	sche, err := CreateScheduler(types.BalanceHotRegionScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigJSONDecoder([]byte("null")))
+	re.NoError(err)
+	hb := sche.(*hotScheduler)
+
+	labels := []map[string]string{
+		{"type": "move-leader", "rw": "read", "store": "12345", "direction": "in", "dim": "cpu-only"},
+		{"type": "transfer-leader", "rw": "read", "store": "12345", "direction": "out", "dim": "cpu"},
+		{"type": "move-peer", "rw": "write", "store": "12345", "direction": "out-for-revert", "dim": "all"},
+	}
+	for _, metricLabels := range labels {
+		_, ok := getHotDirectionCounterValue(t, metricLabels)
+		re.False(ok)
+	}
+
+	hb.prepareForBalance(readLeader, tc)
+
+	for _, metricLabels := range labels {
+		value, ok := getHotDirectionCounterValue(t, metricLabels)
+		re.True(ok, "metric labels=%v should exist after pre-initialization", metricLabels)
+		re.Zero(value)
+	}
 }
 
 func TestUpgrade(t *testing.T) {


### PR DESCRIPTION
## Summary
- preinitialize hot direction counter labelsets for known stores before the first finished hot op
- avoid missing the first jump in store-level monitoring panels that aggregate hot direction counters
- add a focused test that verifies zero-valued series exist before scheduling

## Validation
- go test ./pkg/schedule/schedulers -run 'TestPreInitializeHotDirectionCounters|TestHotReadRegionScheduleWithRevertRegionsDimSecond|TestFilterHotPeersWithDecisions|TestHotReadRegionScheduleWithSmallHotRegion|TestMaxZombieDuration|TestBucketFirstStat|TestExpect|TestSplitBucketsByLoad'\n- go build -tags without_dashboard ./cmd/pd-server